### PR TITLE
Update fuzzing_directed.h

### DIFF
--- a/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
+++ b/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
@@ -962,7 +962,7 @@ namespace fuzz
         __inline virtual _Type** operator&() throw()
         {
             m_ftEffectiveTraits |= TRAIT_TRANSFER_ALLOCATION;
-            return (this->m_fFuzzed) ? &(this->m_t) : &CFuzzType<_Type, _Args...>::m_tInit;
+            return (this->m_fFuzzed) ? &(this->m_t) : &(this->m_tInit);
         }
 
     private:


### PR DESCRIPTION
The code was confused between a bound pointer to a member (i.e., the address of this member in this instance) and a pointer-to-member (i.e., the offset of this member within the class). A recent build of the Visual C++ Compiler (correctly) complains about the attempt to create the pointer-to-member as the member in question is protected - it also complains as it cannot bring the two sides of the ':' to a common type.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
